### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+qabc (1.9.3-2) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster (oldstable):
+    + Build-Depends: Drop versioned constraint on qt5-qmake, qtbase5-dev and
+      qttools5-dev-tools.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 06 Oct 2022 23:58:31 -0000
+
 qabc (1.9.3-1) unstable; urgency=medium
 
   * New upstream release 1.9.3.

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: qabc
 Section: sound
 Priority: optional
 Maintainer: Benoît Rouits <brouits@free.fr>
-Build-Depends: debhelper-compat (= 13), qt5-qmake (>= 5.9), qtbase5-dev (>= 5.9), qttools5-dev-tools (>= 5.9)
+Build-Depends: debhelper-compat (= 13), qt5-qmake, qtbase5-dev, qttools5-dev-tools
 Standards-Version: 4.6.1
 Homepage: http://brouits.free.fr/qabc/
 Vcs-Git: https://github.com/be1/qabc.git


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/qabc/fd8ec252-1b72-45cc-bfcc-ce3e3c4fd64a.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/be/ca301cefc6b6bad5bae5ffe3ed80074594bf57.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/e7/50882053802587da710c9c188cd7ee997afaba.debug

No differences were encountered between the control files of package \*\*qabc\*\*
### Control files of package qabc-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-e750882053802587da710c9c188cd7ee997afaba-] {+beca301cefc6b6bad5bae5ffe3ed80074594bf57+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/fd8ec252-1b72-45cc-bfcc-ce3e3c4fd64a/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/fd8ec252-1b72-45cc-bfcc-ce3e3c4fd64a/diffoscope)).
